### PR TITLE
Refactor to better follow the PEP8 standard

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,10 @@ before_install:
 # Install packages
 install:
   - conda install --yes python=$TRAVIS_PYTHON_VERSION atlas numpy scipy matplotlib nose pip theano flake8
-  - pip install coverage coveralls pep257
+  - pip install coverage coveralls
 
 before_script:
   - flake8 --max-line-length=99 .
-  - pep257 .
 
 # Run test
 script:

--- a/example.py
+++ b/example.py
@@ -1,6 +1,5 @@
-
 import numpy as np
-from mle import *
+from mle import var, Normal
 
 # Define model
 x = var('x', observed=True, vector=True)
@@ -19,4 +18,3 @@ ys = 0.5 * xs + 0.3 + np.random.normal(0, 0.1, 20)
 # Fit model to data
 result = model.fit({'x': xs, 'y': ys}, {'a': 1, 'b': 1, 'sigma': 1})
 print(result)
-

--- a/mle/__init__.py
+++ b/mle/__init__.py
@@ -1,3 +1,12 @@
-from .distributions import *
-from .model import *
-from .variable import *
+from mle.distributions import Join, Mix2, Normal, Uniform
+from mle.model import Model
+from mle.variable import var
+
+__all__ = [
+    Join,
+    Mix2,
+    Model,
+    Normal,
+    Uniform,
+    var,
+]

--- a/mle/distributions/__init__.py
+++ b/mle/distributions/__init__.py
@@ -1,47 +1,63 @@
-
 import numpy as np
 import theano.tensor as T
-from numpy import inf, array, ndarray
 
 from mle.model import Model
 
-__all__=['Uniform', 'Normal', 'Mix2', 'Join']
+__all__ = ['Uniform', 'Normal', 'Mix2', 'Join']
 
-def alltrue(vals):
+
+def alltrue(conditionals):
     ret = 1
-    for c in vals:
-        ret = ret * (1 * c)
+    for condition in conditionals:
+        ret *= condition
     return ret
 
-def bound(logp, *conditions):
-    return T.switch(alltrue(conditions), logp, -np.inf)
+
+def bound(logp, *conditionals):
+    return T.switch(alltrue(conditionals), logp, -np.inf)
+
 
 class Uniform(Model):
     def __init__(self, x, lower, upper, *args, **kwargs):
         super(Uniform, self).__init__(*args, **kwargs)
-        self._logp = T.log(T.switch(T.gt(x, upper), 0, T.switch(T.lt(x, lower), 0, 1/(upper - lower))))
-        self._cdf = T.switch(T.gt(x, up), 1, T.switch(T.lt(x, low), 0, (x - low)/(up - low)))
+        self._logp = T.log(T.switch(
+            T.gt(x, upper), 0,
+            T.switch(T.lt(x, lower), 0, 1/(upper-lower))
+        ))
+        self._cdf = T.switch(
+            T.gt(x, upper), 1,
+            T.switch(T.lt(x, lower), 0, (x-lower)/(upper-lower))
+        )
         self._add_expr('x', x)
         self._add_expr('lower', lower)
         self._add_expr('upper', upper)
 
+
 class Normal(Model):
     def __init__(self, x, mu, sigma, *args, **kwargs):
         super(Normal, self).__init__(*args, **kwargs)
-        self._logp = bound(-(x - mu)**2 / (2 * sigma**2) + T.log(1 / T.sqrt(sigma**2 * 2 * np.pi)), sigma > 0)
+        self._logp = bound(
+            -(x - mu)**2 / (2 * sigma**2) + T.log(1 / T.sqrt(sigma**2 * 2*np.pi)),
+            sigma > 0
+        )
         self._cdf = 0.5 * (1 + T.erf((x - mu)/(sigma*T.sqrt(2))))
         self._add_expr('x', x)
         self._add_expr('mu', mu)
         self._add_expr('sigma', sigma)
 
+
 class Mix2(Model):
     def __init__(self, theta, dist1, dist2, *args, **kwargs):
         super(Mix2, self).__init__(*args, **kwargs)
-        self._logp = bound(T.log(theta * T.exp(dist1._logp) + (1 - theta) * T.exp(dist2._logp)), theta > 0, theta < 1)
-        self._cdf = lambda: self.theta * self.dist1._cdf + (1-self.theta) * self.dist2._cdf
+        self._logp = bound(
+            T.log(theta*T.exp(dist1._logp) + (1-theta)*T.exp(dist2._logp)),
+            theta >= 0, theta <= 1
+        )
+        self._cdf = lambda: self.theta*self.dist1._cdf + (1-self.theta)*self.dist2._cdf
         self._add_expr('theta', theta)
         self._add_submodel('dist1', dist1)
         self._add_submodel('dist2', dist2)
+
 
 class Join(Model):
     def __init__(self, dist1, dist2=None, *args, **kwargs):
@@ -52,4 +68,3 @@ class Join(Model):
         else:
             self._add_submodel('dist2', dist2)
             self._logp = dist1._logp + dist2._logp
-

--- a/mle/minuit.py
+++ b/mle/minuit.py
@@ -1,20 +1,22 @@
-
 try:
     from iminuit import Minuit
-except:
-    raise ImportError("The iminuit package needs to be "
-                      "installed in order to use `method='MINUIT'`")
+except ImportError:
+    raise ImportError("The iminuit package must be installed in order to use `method='MINUIT'`")
 
 from iminuit.util import make_func_code
 from scipy.optimize import OptimizeResult
 
+
 class Min_Func:
+
     def __init__(self, f, names):
         self.f = f
         self.func_code = make_func_code(names)
         self.func_defaults = None
+
     def __call__(self, *args):
         return self.f(args)
+
 
 def fmin_minuit(func, x0, names=None, verbose=False):
     inits = dict()
@@ -38,11 +40,10 @@ def fmin_minuit(func, x0, names=None, verbose=False):
     a, b = m.migrad()
 
     return OptimizeResult(
-            x=m.values,
-            fun=a['fval'],
-            edm=a['edm'],
-            nfev=a['nfcn'],
-            is_valid=a['is_valid'],
-            has_valid_parameters=a['has_valid_parameters'],
+        x=m.values,
+        fun=a['fval'],
+        edm=a['edm'],
+        nfev=a['nfcn'],
+        is_valid=a['is_valid'],
+        has_valid_parameters=a['has_valid_parameters'],
     )
-

--- a/mle/util.py
+++ b/mle/util.py
@@ -1,17 +1,17 @@
-from theano import Variable, scan, pp
-from theano.tensor import grad, stack, concatenate
-from theano.gradient import format_as
-from theano.printing import debugprint
 import functools
 
-def hessian_(cost, wrt, consider_constant=None,
-            disconnected_inputs='raise'):
+from theano import Variable, scan
+from theano.tensor import arange, grad, stack
+from theano.gradient import format_as
+
+
+def hessian_(cost, wrt, consider_constant=None, disconnected_inputs='raise'):
     """
+
     :type cost: Scalar (0-dimensional) Variable.
     :type wrt: Vector (1-dimensional tensor) 'Variable' or list of
                vectors (1-dimensional tensors) Variables
-    :param consider_constant: a list of expressions not to backpropagate
-        through
+    :param consider_constant: a list of expressions not to backpropagate through
     :type disconnected_inputs: string
     :param disconnected_inputs: Defines the behaviour if some of the variables
         in ``wrt`` are not part of the computational graph computing ``cost``
@@ -26,12 +26,9 @@ def hessian_(cost, wrt, consider_constant=None,
             variable is returned. The return value is of same type
             as `wrt`: a list/tuple or TensorVariable in all cases.
     """
-    from theano.tensor import arange
     # Check inputs have the right format
-    assert isinstance(cost, Variable), \
-            "tensor.hessian expects a Variable as `cost`"
-    assert cost.ndim == 0, \
-            "tensor.hessian expects a 0 dimensional variable as `cost`"
+    assert isinstance(cost, Variable), "tensor.hessian expects a Variable as `cost`"
+    assert cost.ndim == 0, "tensor.hessian expects a 0 dimensional variable as `cost`"
 
     using_list = isinstance(wrt, list)
     using_tuple = isinstance(wrt, tuple)
@@ -47,23 +44,19 @@ def hessian_(cost, wrt, consider_constant=None,
     # It is possible that the inputs are disconnected from expr,
     # even if they are connected to cost.
     # This should not be an error.
-    hess, updates = scan(lambda i, y: grad(
-                        y[i],
-                        wrt,
-                        consider_constant=consider_constant,
-                        disconnected_inputs='ignore'),
-                   sequences=arange(len(expr)),
-                   non_sequences=[expr])
-    assert not updates, \
-            ("Scan has returned a list of updates. This should not "
-             "happen! Report this to theano-users (also include the "
-             "script that generated the error)")
+    hess, updates = scan(
+        lambda i, y: grad(y[i], wrt, consider_constant=consider_constant,
+                          disconnected_inputs='ignore'),
+        sequences=arange(len(expr)), non_sequences=[expr]
+    )
+    assert not updates, ("Scan has returned a list of updates. This should not happen! Report "
+                         "this to theano-users (also include the script that generated the error)")
+
     return format_as(using_list, using_tuple, stack(hess)[0])
 
+
 def memoize(obj):
-    """
-    An expensive memoizer that works with unhashables
-    """
+    """An expensive memoizer that works with unhashables."""
     cache = obj.cache = {}
 
     @functools.wraps(obj)
@@ -76,10 +69,9 @@ def memoize(obj):
         return cache[key]
     return memoizer
 
+
 def hashable(a):
-    """
-    Turn some unhashable objects into hashable ones.
-    """
+    """Turn some unhashable objects into hashable ones."""
     if isinstance(a, dict):
         return hashable(a.items())
     try:

--- a/mle/variable.py
+++ b/mle/variable.py
@@ -1,8 +1,8 @@
-
 import theano.tensor as T
 import numpy as np
 
 __all__ = ['var']
+
 
 def var(name, label=None, observed=False, const=False, vector=False, lower=None, upper=None):
     if vector and not observed:
@@ -19,19 +19,8 @@ def var(name, label=None, observed=False, const=False, vector=False, lower=None,
     var._name = name
     var._label = label
     var._observed = observed
-    if observed:
-        var._const = True
-    else:
-        var._const = const
-    if lower is None:
-        var._lower = -np.inf
-    else:
-        var._lower = lower
-    if upper is None:
-        var._upper = np.inf
-    else:
-        var._upper = upper
+    var._const = observed or const
+    var._lower = lower or -np.inf
+    var._upper = upper or np.inf
 
     return var
-
-

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,3 @@
-from nose.tools import raises
-
 def test_formula_transform():
     """
     Check if variables can be added/multiplied/transformed.
@@ -11,7 +9,8 @@ def test_formula_transform():
     a = var('a')
     b = var('b')
 
-    formula = a * x**2 + b
+    a * x**2 + b
+
 
 def test_const():
     """
@@ -30,6 +29,7 @@ def test_const():
     results = model.fit({'x': data}, {'mu': 1, 'sigma': 1})
     assert(results.x['mu'] == 1)
 
+
 # @raises(ValueError)
 # def test_error_on_illegal_bound():
 #     """
@@ -45,6 +45,7 @@ def test_const():
 #     sigma = var('sigma', lower=-1)
 
 #     Normal(x, mu, sigma)
+
 
 def test_simple_fit():
     """
@@ -63,9 +64,10 @@ def test_simple_fit():
     data = np.random.normal(0, 1, 100000)
 
     try:
-        results = dist.fit({'x': data}, {'mu': 1, 'sigma': 2}, method='BFGS')
+        dist.fit({'x': data}, {'mu': 1, 'sigma': 2}, method='BFGS')
     except:
         assert False, 'Fitting generated data failed'
+
 
 def test_linear_regression():
     """
@@ -87,8 +89,9 @@ def test_linear_regression():
     xs = np.linspace(0, 1, 20)
     ys = 0.5 * xs - 0.3 + np.random.normal(0, 0.2, 20)
 
-    results = model.fit({'x': xs, 'y':ys}, {'a': 2, 'b': 1, 'sigma': 1})
+    results = model.fit({'x': xs, 'y': ys}, {'a': 2, 'b': 1, 'sigma': 1})
     print(results)
+
 
 def test_pdf_product():
     """
@@ -102,5 +105,3 @@ def test_pdf_product():
 
     model = Join(Join(Normal(x, mu, sigma)), Normal(y, mu, sigma))
     assert(model.observed == [x, y])
-
-


### PR DESCRIPTION
I've probably missed lots of subtler things but `flake8` is now happy when ran with `--max-line-length=99`, let me know if you dislike any of the changes or thing they could be done better in other ways.

I've also abandoned the `pep257` test in Travis as its too strict, requiring documentation to be duplicated in some places.