### PR TITLE
bugfix: implicit import

### DIFF
--- a/mle/__init__.py
+++ b/mle/__init__.py
@@ -3,10 +3,10 @@ from mle.model import Model
 from mle.variable import var
 
 __all__ = [
-    Join,
-    Mix2,
-    Model,
-    Normal,
-    Uniform,
-    var,
+    "Join",
+    "Mix2",
+    "Model",
+    "Normal",
+    "Uniform",
+    "var",
 ]


### PR DESCRIPTION
I ran the example from [README.md](https://github.com/ibab/python-mle/blob/master/README.md) and it does not work because the implementation of the implicit import is wrong.

Currently, the problem with the implicit import of mle is that `__all__` in mle/\_\_init\_\_ should be a list of strings and not a list of classes. See official Python documentation https://docs.python.org/3/tutorial/modules.html#importing-from-a-package for more info.

Before the fix:
```python
>>> from mle import *
TypeError: Item in mle.__all__ must be str, not type
```

After the fix this works.